### PR TITLE
Fix reliance on '/home/hamish' hard-encoding

### DIFF
--- a/projects/CFPN/train.py
+++ b/projects/CFPN/train.py
@@ -120,7 +120,7 @@ class Trainer(DefaultTrainer):
 def setup(args):
     cfg = get_cfg()
     add_cfpn_config(cfg)
-    cfg.merge_from_file('/home/hamish/detectron2/projects/CFPN/configs/quantized_multilevel_residual_CFPN_1x.yaml')
+    cfg.merge_from_file(os.getenv("HOME") + '/detectron2/projects/CFPN/configs/quantized_multilevel_residual_CFPN_1x.yaml')
     # cfg.merge_from_list(args.opts)
     download_kodak()
     register_kodak()
@@ -131,7 +131,7 @@ def setup(args):
 
 
 if __name__ == "__main__":
-    os.chdir("/home/hamish")
+    os.chdir(os.getenv("HOME"))
     cfg = setup([])
     trainer = Trainer(cfg)
     trainer.train()


### PR DESCRIPTION
Uses environment variable for HOME instead. Note, if you have trouble finding the KODAK dataset when running `train.py`, try setting environment variable `$DETECTRON2_DATASETS` to the location of your dataset.